### PR TITLE
Update `Anime` and `AnimeExtended` to match Jikan API docs

### DIFF
--- a/src/common/structs/anime.rs
+++ b/src/common/structs/anime.rs
@@ -1,7 +1,5 @@
 use crate::{
-    response::MalCommonResponse,
-    structs::{forum::ForumTopic, people::Person, watch::Trailer},
-    utils::{DateRange, Images, Score, Title},
+    common::utils::{ExternalEntry, Relations, Theme}, response::MalCommonResponse, structs::{forum::ForumTopic, people::Person, watch::Trailer}, utils::{DateRange, Images, Score, Title}
 };
 use serde::{Deserialize, Serialize};
 
@@ -10,15 +8,39 @@ pub struct Anime {
     pub mal_id: u32,
     pub url: String,
     pub images: Images,
+    pub trailer: Option<Trailer>,
+    pub approved: Option<bool>,
+    pub titles: Option<Vec<Title>>,
     pub title: String,
-    pub start_year: Option<u32>,
     pub title_english: Option<String>,
     pub title_japanese: Option<String>,
+    pub title_synonyms: Option<Vec<String>>,
+    pub r#type: Option<String>,
+    pub source: Option<String>,
     pub episodes: Option<u32>,
     pub status: Option<String>,
-    pub score: Option<f32>,
-    pub synopsis: Option<String>,
+    pub airing: Option<bool>,
     pub aired: Option<DateRange>,
+    pub duration: Option<String>,
+    pub rating: Option<String>,
+    pub score: Option<f32>,
+    pub scored_by: Option<u32>,
+    pub rank: Option<u32>,
+    pub popularity: Option<u32>,
+    pub members: Option<u32>,
+    pub favorites: Option<u32>,
+    pub synopsis: Option<String>,
+    pub background: Option<String>,
+    pub season: Option<String>,
+    pub year: Option<u32>,
+    pub broadcast: Option<Broadcast>,
+    pub producers: Option<Vec<MalCommonResponse>>,
+    pub licensors: Option<Vec<MalCommonResponse>>,
+    pub studios: Option<Vec<MalCommonResponse>>,
+    pub genres: Option<Vec<MalCommonResponse>>,
+    pub explicit_genres: Option<Vec<MalCommonResponse>>,
+    pub themes: Option<Vec<MalCommonResponse>>,
+    pub demographics: Option<Vec<MalCommonResponse>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,6 +89,10 @@ pub struct AnimeExtended {
     pub explicit_genres: Option<Vec<MalCommonResponse>>,
     pub themes: Option<Vec<MalCommonResponse>>,
     pub demographics: Option<Vec<MalCommonResponse>>,
+    pub relations: Relations,
+    pub theme: Theme,
+    pub external: Vec<ExternalEntry>,
+    pub streaming: Vec<ExternalEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/common/structs/anime.rs
+++ b/src/common/structs/anime.rs
@@ -1,5 +1,8 @@
 use crate::{
-    common::utils::{ExternalEntry, Relations, Theme}, response::MalCommonResponse, structs::{forum::ForumTopic, people::Person, watch::Trailer}, utils::{DateRange, Images, Score, Title}
+    common::utils::{ExternalEntry, Relations, Theme},
+    response::MalCommonResponse,
+    structs::{forum::ForumTopic, people::Person, watch::Trailer},
+    utils::{DateRange, Images, Score, Title},
 };
 use serde::{Deserialize, Serialize};
 
@@ -89,7 +92,7 @@ pub struct AnimeExtended {
     pub explicit_genres: Option<Vec<MalCommonResponse>>,
     pub themes: Option<Vec<MalCommonResponse>>,
     pub demographics: Option<Vec<MalCommonResponse>>,
-    pub relations: Relations,
+    pub relations: Vec<Relations>,
     pub theme: Theme,
     pub external: Vec<ExternalEntry>,
     pub streaming: Vec<ExternalEntry>,

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::common::response::MalCommonResponse;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pagination {
     pub last_visible_page: i32,
@@ -66,4 +68,16 @@ pub struct Score {
     pub score: i32,
     pub votes: i32,
     pub percentage: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Relations {
+    pub relation: String,
+    pub entry: Vec<MalCommonResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Theme {
+    pub openings: Vec<String>,
+    pub endings: Vec<String>,
 }

--- a/src/seasons.rs
+++ b/src/seasons.rs
@@ -1,6 +1,6 @@
 use crate::{
     JikanClient, JikanError,
-    common::response::Response,
+    common::{response::Response, structs::anime::AnimeExtended},
     enums::season::SeasonFilter,
     structs::{anime::Anime, season::SeasonInfo},
 };
@@ -105,7 +105,7 @@ impl JikanClient {
     pub async fn get_season_now(
         &self,
         params: Option<SeasonQueryParams>,
-    ) -> Result<Response<Vec<Anime>>, JikanError> {
+    ) -> Result<Response<Vec<AnimeExtended>>, JikanError> {
         let mut query_params = Vec::new();
 
         if let Some(p) = params {

--- a/src/seasons.rs
+++ b/src/seasons.rs
@@ -1,6 +1,6 @@
 use crate::{
     JikanClient, JikanError,
-    common::{response::Response, structs::anime::AnimeExtended},
+    common::response::Response,
     enums::season::SeasonFilter,
     structs::{anime::Anime, season::SeasonInfo},
 };
@@ -105,7 +105,7 @@ impl JikanClient {
     pub async fn get_season_now(
         &self,
         params: Option<SeasonQueryParams>,
-    ) -> Result<Response<Vec<AnimeExtended>>, JikanError> {
+    ) -> Result<Response<Vec<Anime>>, JikanError> {
         let mut query_params = Vec::new();
 
         if let Some(p) = params {


### PR DESCRIPTION
## A complete check on the return type structures to address missing fields - Fixes #21 

- Updated `Anime` and `AnimeExtended` structs
- Revert return type of `get_seasons_now()` to `Anime`